### PR TITLE
FilReader.bandpass(): Divide by samples read, rather than total samples in the filterbank

### DIFF
--- a/sigpyproc/Filterbank.py
+++ b/sigpyproc/Filterbank.py
@@ -121,12 +121,14 @@ class Filterbank(object):
         """
         bpass_ar = np.zeros(self.header.nchans, dtype="float64")
         bpass_ar_c = as_c(bpass_ar)
+        num_samples = 0
         for nsamps, ii, data in self.readPlan(gulp, **kwargs):
             self.lib.getBpass(as_c(data),
                               bpass_ar_c,
                               C.c_int(self.header.nchans),
                               C.c_int(nsamps))
-        bpass_ar = bpass_ar/self.header.nsamples
+            num_samples += nsamps
+        bpass_ar = bpass_ar/num_samples
         return TimeSeries(bpass_ar, self.header.newHeader({"nchans":1}))
 
     def dedisperse(self, dm, gulp=10000, **kwargs):


### PR DESCRIPTION
Currently, calling .bandpass() on a FilReader will divide the output by the total number of samples in the filterbank. However, the function has been setup to allow the readPlan to be configured through passing extra kwargs to the function, so this isn't always the number of samples represented by the output bandpass array

This PR changes the loop to sum up the number of time samples being processed, then use this variable to divide the output bandpass. 

Comparisons of before (left) / after (right) with different set ups, plotting the log of the bandpass, note that only the axis labelling is changing.

```rdr.bandpass(start = 0, nsamps = int(0.003 * rdr.header.nsamples))```
![image](https://user-images.githubusercontent.com/43447097/97319350-b35dd780-1864-11eb-80d3-d75a83786499.png)

```rdr.bandpass(start =  int(0.5 * rdr.header.nsamples), nsamps = int(0.003 * rdr.header.nsamples))```
![image](https://user-images.githubusercontent.com/43447097/97319873-2ff0b600-1865-11eb-9ddb-50d0b0090a0b.png)
