### PR TITLE
Fix macOS installation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies on ${{ matrix.os }}
+    - name: Install dependencies for macOS
       if: startsWith(matrix.os, 'macos')
       run: |
-        brew install libomp
-    - name: Install dependencies on ${{ matrix.os }}
+        brew install libomp fftw
+    - name: Install dependencies for ubuntu
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get -y install build-essential fftw3 fftw3-dev
-        python -m pip install --upgrade pip setuptools wheel
     - name: Install it
       run: |
-        python -m pip install -e .[tests] -v
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -e .[tests]
     - name: Simple test
       run: |
         python examples/dedisperse.py examples/tutorial.fil 300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04, macos-latest]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
@@ -21,6 +22,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install dependencies on ${{ matrix.os }}
+      if: startsWith(matrix.os, 'macOS')
+      run: |
+        brew install libomp
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -28,13 +33,10 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
     - name: Install it
       run: |
-        python -m pip install -e .[tests]
+        python -m pip install -e .[tests] -v
     - name: Simple test
       run: |
         python examples/dedisperse.py examples/tutorial.fil 300
-    #- name: Copy shared libs
-    #  run: |
-    #    find build/ -type f -name "*.so" -exec cp {} sigpyproc/ \;
     - name: Lint with flake8
       run: |
         pip install flake8 wemake-python-styleguide
@@ -53,4 +55,3 @@ jobs:
         file: ./coverage.xml
         name: codecov-umbrella
         fail_ci_if_error: true
-        verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies on ${{ matrix.os }}
-      if: startsWith(matrix.os, 'macOS')
+      if: startsWith(matrix.os, 'macos')
       run: |
         brew install libomp
-    - name: Install dependencies
+    - name: Install dependencies on ${{ matrix.os }}
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get -y install build-essential fftw3 fftw3-dev

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,9 +3,10 @@
 Installation
 ============
 
-You need Python 3.6 or later to run sigpyproc. Additionally,
-`FFTW3 <http://www.fftw.org/>`_ and `OpenMP <https://www.openmp.org/>`_
-should be installed/enabled on your system.
+You need Python 3.6 or later to run sigpyproc. Additionally, FFTW3_ and
+OpenMP_ should be installed/enabled on your system. The ``setup.py`` script
+will search for FFTW3_ library in default places. In case of a custom
+installation, you can define ``FFTW_PATH`` before installing sigpyproc.
 
 From source
 -----------
@@ -25,14 +26,23 @@ or clone the source repository and install from there
     cd sigpyproc3
     python -m pip install .
 
+.. note::
+
+    On macOS you'll want to install ``libomp`` from Homebrew to use OpenMP with
+    the default Clang compiler.
+
 
 Test the installation
 ---------------------
 
-You can execute some unit and benchmark tests using
-`pytest <https://docs.pytest.org>`_ to make sure that the installation went
-alright. In the root directory of the source code execute the following command:
+You can execute some unit and benchmark tests using pytest_ to make sure that the
+installation went alright. In the root directory of the source code
+execute the following command:
 
 .. code-block:: bash
 
     python -m pytest -v tests
+
+.. _pytest: https://docs.pytest.org
+.. _FFTW3: http://www.fftw.org/
+.. _OpenMP: https://www.openmp.org/

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def append_path(dirs_list, *args):
 
 
 def get_include_dirs():
-    prefix_dirs = ['/usr']
+    prefix_dirs = ['/usr', '/usr/local']
     dirs = []
     sys_include = sysconfig.get_config_var('INCLUDEDIR')
     if 'FFTW_PATH' in os.environ:
@@ -57,7 +57,7 @@ def get_include_dirs():
 
 
 def get_library_dirs():
-    prefix_dirs = ['/usr']
+    prefix_dirs = ['/usr', '/usr/local']
     dirs = []
     sys_lib = sysconfig.get_config_var('LIBDIR')
     if 'FFTW_PATH' in os.environ:

--- a/sigpyproc/__init__.py
+++ b/sigpyproc/__init__.py
@@ -1,3 +1,3 @@
 from sigpyproc.Readers import FilReader
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
Apple `clang` doesn't support libomp by default. Now testing with `-Xpreprocessor -fopenmp`.
Need to install Homebrew `libomp`. 