### PR TITLE
Add SRT sigproc telescope code as 10

### DIFF
--- a/sigpyproc/HeaderParams.py
+++ b/sigpyproc/HeaderParams.py
@@ -120,7 +120,8 @@ telescope_ids = {
     "GMRT": 7,
     "Effelsberg": 8,
     "Effelsberg LOFAR": 9,
-    "Unknown": 10,
+    "SRT": 10,
+    "Unknown": 11,
 }
 
 ids_to_telescope = dict(zip(telescope_ids.values(), telescope_ids.keys()))


### PR DESCRIPTION
On request from Marta Burgay, the Sardinia radio telescope code should be added to sigpyproc. Sigproc and DSPSR both use code 10 for the SRT.