### PR TITLE
#33 Implementation of buffered file read (WIP)

### DIFF
--- a/sigpyproc/core/kernels.py
+++ b/sigpyproc/core/kernels.py
@@ -5,10 +5,9 @@ from numba.experimental import jitclass
 from scipy import constants
 
 
-@njit("u1[:](u1[:])", cache=True, parallel=True)
-def unpack1_8(array):
+@njit("u1[:](u1[:], u1[:])", cache=True, parallel=True)
+def unpack1_8(array, unpacked):
     bitfact = 8
-    unpacked = np.zeros(shape=array.size * bitfact, dtype=np.uint8)
     for ii in prange(array.size):
         unpacked[ii * bitfact + 0] = (array[ii] >> 7) & 1
         unpacked[ii * bitfact + 1] = (array[ii] >> 6) & 1
@@ -21,10 +20,9 @@ def unpack1_8(array):
     return unpacked
 
 
-@njit("u1[:](u1[:])", cache=True, parallel=True)
-def unpack2_8(array):
+@njit("u1[:](u1[:], u1[:])", cache=True, parallel=True)
+def unpack2_8(array, unpacked):
     bitfact = 8 // 2
-    unpacked = np.zeros(shape=array.size * bitfact, dtype=np.uint8)
     for ii in prange(array.size):
         unpacked[ii * bitfact + 0] = (array[ii] & 0xC0) >> 6
         unpacked[ii * bitfact + 1] = (array[ii] & 0x30) >> 4
@@ -33,10 +31,9 @@ def unpack2_8(array):
     return unpacked
 
 
-@njit("u1[:](u1[:])", cache=True, parallel=True)
-def unpack4_8(array):
+@njit("u1[:](u1[:], u1[:])", cache=True, parallel=True)
+def unpack4_8(array, unpacked):
     bitfact = 8 // 4
-    unpacked = np.zeros(shape=array.size * bitfact, dtype=np.uint8)
     for ii in prange(array.size):
         unpacked[ii * bitfact + 0] = (array[ii] & 0xF0) >> 4
         unpacked[ii * bitfact + 1] = (array[ii] & 0x0F) >> 0

--- a/sigpyproc/io/bits.py
+++ b/sigpyproc/io/bits.py
@@ -9,7 +9,7 @@ from sigpyproc.core import kernels
 nbits_to_dtype = {1: "<u1", 2: "<u1", 4: "<u1", 8: "<u1", 16: "<u2", 32: "<f4"}
 
 
-def unpack(array: np.ndarray, nbits: int) -> np.ndarray:
+def unpack(array: np.ndarray, nbits: int, unpacked: np.ndarray = None) -> np.ndarray:
     """Unpack 1, 2 and 4 bit array. Only unpacks in big endian bit ordering.
 
     Parameters
@@ -30,12 +30,18 @@ def unpack(array: np.ndarray, nbits: int) -> np.ndarray:
         if nbits is not 1, 2, or 4
     """
     assert array.dtype == np.uint8, "Array must be uint8"
+    bitfact = 8//nbits
+    if unpacked is None:
+        unpacked = np.zeros(shape=array.size * bitfact, dtype=np.uint8)
+    else:
+        if unpacked.size != array.size * bitfact:
+            raise ValueError(f"Unpacking array must be {bitfact}x input size")
     if nbits == 1:
-        unpacked = np.unpackbits(array, bitorder="big")
+        unpacked = kernels.unpack1_8(array, unpacked)
     elif nbits == 2:
-        unpacked = kernels.unpack2_8(array)
+        unpacked = kernels.unpack2_8(array, unpacked)
     elif nbits == 4:
-        unpacked = kernels.unpack4_8(array)
+        unpacked = kernels.unpack4_8(array, unpacked)
     else:
         raise ValueError("nbits must be 1, 2, or 4")
     return unpacked


### PR DESCRIPTION
Based on issue #33, I have added some features to support buffered inputs for file reading. The code is currently implemented under a new `read_plan_buffered` method on `FilReader` but as the behaviour is identical to that of `read_plan` (barring one optional argument) it may be sensible to replace the original code with the buffered code. 

Tests are still underway but so far for all of the test files included in the repo both the old and new code give the same results.

Testing on larger files also shows that this results in a significant performance improvement. For example, testing the time required to read and unpack a 2 GB file on a MacBook with an M2 processor we see a doubling of the performance:

```
In [48]: %timeit test_buffered()
147 ms ± 1.05 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [49]: %timeit test()
330 ms ± 779 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```