### PR TITLE
slice_bugfix

### DIFF
--- a/sigpyproc/readers.py
+++ b/sigpyproc/readers.py
@@ -124,8 +124,11 @@ class FilReader(Filterbank):
                     min_sample <= samples_offset,
                 ),
             ).flatten()
-            chans_slice = slice(relevant_chans.min(), relevant_chans.max() + 1)
-
+            chans_slice = np.arange(
+                relevant_chans.min(),
+                relevant_chans.max() + 1,
+                dtype=int,
+            )
             # Read channel data for for each sample
             sample_data = self._file.cread(self.header.nchans)
             data[chans_slice, samples_read[chans_slice]] = sample_data[chans_slice]

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -32,11 +32,12 @@ class TestFilReader:
 
     def test_read_dedisp_block(self, filfile_8bit_1: str) -> None:
         fil = FilReader(filfile_8bit_1)
-        dm = 10
-        block = fil.read_dedisp_block(0, 100, dm)
+        dm = 0
+        block = fil.read_block(0, fil.header.nsamples)
+        block_dd = fil.read_dedisp_block(0, fil.header.nsamples, dm)
         assert isinstance(block, FilterbankBlock)
         assert isinstance(block.header, Header)
-        np.testing.assert_equal(block.dm, dm)
+        np.testing.assert_equal(block, block_dd)
 
     def test_read_dedisp_block_outofrange(self, filfile_8bit_1: str) -> None:
         fil = FilReader(filfile_8bit_1)


### PR DESCRIPTION
python slice is causing wrong indexing in `read_dedisp_block`. For now, changing it back to numpy.