### PR TITLE
matched filter improved.

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -9,6 +9,15 @@
    :show-inheritance:
 ```
 
+## sigpyproc.core.filters
+
+```{eval-rst}
+.. automodule:: sigpyproc.core.filters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
 ## sigpyproc.core.rfi
 
 ```{eval-rst}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,13 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+from __future__ import annotations
+
 import datetime
+import inspect
+import os
 import sys
+from importlib import import_module
 from importlib.metadata import version as meta_version
 from pathlib import Path
 
@@ -26,6 +31,7 @@ copyright = f"{year}, {author}"  # noqa: A001
 version = meta_version("sigpyproc")
 release = version
 master_doc = "index"
+repo_url = "https://github.com/FRBs/sigpyproc3"
 
 # -- General configuration ---------------------------------------------------
 
@@ -33,14 +39,15 @@ master_doc = "index"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "numpydoc",
-    "sphinx_autodoc_typehints",
     "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
     "sphinx_click",
     "sphinx-prompt",
     "sphinx_copybutton",
+    "numpydoc",
     "myst_nb",
+    "jupyter_sphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -62,36 +69,30 @@ nitpicky = True
 # a list of builtin themes.
 
 html_theme = "sphinx_book_theme"
+html_context = {"default_mode": "light"}
 html_title = project
 html_theme_options = {
-    "repository_url": "https://github.com/FRBs/sigpyproc3",
+    "repository_url": repo_url,
     "use_repository_button": True,
     "use_issues_button": True,
     "use_download_button": True,
 }
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-# \html_static_path = ["_static"]
 
 # -- Extension configuration -------------------------------------------------
 
 autoclass_content = "class"  # include both class docstring and __init__
 autodoc_member_order = "bysource"
 autodoc_typehints = "none"
-autodoc_inherit_docstrings = True
 
-typehints_document_rtype = False
-
-numpydoc_use_plots = True
-numpydoc_class_members_toctree = False
+numpydoc_show_class_members = False
 numpydoc_show_inherited_class_members = False
+numpydoc_class_members_toctree = False
 numpydoc_xref_param_type = True
 numpydoc_xref_aliases = {
     "ndarray": "numpy.ndarray",
     "dtype": "numpy.dtype",
     "ArrayLike": "numpy.typing.ArrayLike",
-    "plt": "matplotlib.pyplot",
+    "Figure": "matplotlib.figure.Figure",
     "scipy": "scipy",
     "astropy": "astropy",
     "attrs": "attrs",
@@ -99,22 +100,26 @@ numpydoc_xref_aliases = {
     "Buffer": "typing_extensions.Buffer",
     "Iterator": "collections.abc.Iterator",
     "Callable": "collections.abc.Callable",
+    "Literal": "typing.Literal",
 }
 numpydoc_xref_ignore = {
     "of",
+    "or",
     "shape",
     "type",
     "optional",
+    "scalar",
     "default",
 }
 
-
 coverage_show_missing_items = True
 
-myst_enable_extensions = ["colon_fence"]
+myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath"]
 
 nb_execution_mode = "auto"
 nb_execution_timeout = -1
+
+copybutton_prompt_text = ">>> "
 
 # -- Options for intersphinx extension ---------------------------------------
 
@@ -127,3 +132,34 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "typing_extensions": ("https://typing-extensions.readthedocs.io/en/stable/", None),
 }
+
+# -- Linkcode configuration --------------------------------------------------
+
+
+def linkcode_resolve(domain: str, info: dict) -> str | None:
+    """Point to the source code repository, file and line number."""
+    if domain != "py" or not info["module"]:
+        return None
+    try:
+        mod = import_module(info["module"])
+        if "." in info["fullname"]:
+            objname, attrname = info["fullname"].split(".")
+            obj = getattr(getattr(mod, objname), attrname)
+        else:
+            obj = getattr(mod, info["fullname"])
+
+        file = inspect.getsourcefile(obj)
+        lines, start_line = inspect.getsourcelines(obj)
+    except (TypeError, AttributeError, ImportError):
+        return None
+
+    if not file or not lines:
+        return None
+    file_path = Path(file).resolve().relative_to(Path("..").resolve())
+    end_line = start_line + len(lines) - 1
+
+    # Determine the branch based on RTD version
+    rtd_version = os.getenv("READTHEDOCS_VERSION", "latest")
+    github_branch = "develop" if rtd_version == "develop" else "main"
+
+    return f"{repo_url}/blob/{github_branch}/{file_path}#L{start_line}-L{end_line}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "attrs",
     "click",
     "rich",
+    "rocket-fft",
     "bidict",
     "typing_extensions",
 ]
@@ -58,9 +59,9 @@ docs = [
     "sphinx-click",
     "sphinx-prompt",
     "sphinx-copybutton",
-    "sphinx-autodoc-typehints",
-    "myst-nb",
     "numpydoc",
+    "myst-nb",
+    "jupyter_sphinx",
 ]
 develop = ["ruff"]
 
@@ -89,7 +90,7 @@ indent-style = "space"
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["D1", "ANN1", "PLR2004", "G004"]
+ignore = ["D1", "D301", "ANN1", "PLR2004", "G004"]
 
 [tool.ruff.lint.pylint]
 max-args = 15

--- a/sigpyproc/block.py
+++ b/sigpyproc/block.py
@@ -9,7 +9,8 @@ from sigpyproc.utils import roll_array
 
 
 class FilterbankBlock:
-    """An array class to handle a discrete block of data in time-major order.
+    """
+    An array class to handle a discrete block of data in time-major order.
 
     Parameters
     ----------
@@ -19,11 +20,6 @@ class FilterbankBlock:
         header object containing metadata
     dm : float, optional
         DM of the input_array, by default 0
-
-    Returns
-    -------
-    :py:obj:`~numpy.ndarray`
-        2 dimensional array of shape (nchans, nsamples) with header metadata
     """
 
     def __init__(self, data: np.ndarray, hdr: Header, dm: float = 0) -> None:

--- a/sigpyproc/core/stats.py
+++ b/sigpyproc/core/stats.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Literal
 
 import attrs
 import bottleneck as bn
@@ -9,22 +9,36 @@ from astropy import stats as astrostats
 
 from sigpyproc.core import kernels
 
+LocMethodType = Literal["median", "mean"]
+ScaleMethodType = Literal[
+    "iqr",
+    "mad",
+    "doublemad",
+    "diffcov",
+    "biweight",
+    "qn",
+    "sn",
+    "gapper",
+]
+
 
 @attrs.define(auto_attribs=True, slots=True, kw_only=True)
 class ZScoreResult:
-    """Result of a Z-score calculation.
+    """
+    Container for Z-score calculation results.
 
-    Attributes
+    Parameters
     ----------
-    zscores: numpy.ndarray
-        Robust Z-scores of the array.
+    data: ndarray
+        Robust Z-scores of the input array (normalized data).
     loc: float
-        Estimated location used for the Z-score calculation.
-    scale: float | numpy.ndarray
-        Estimated scale used for the Z-score calculation.
+        Estimated location (central tendency) used for the Z-score calculation.
+    scale: float | ndarray
+        Estimated scale (variability) used for the Z-score calculation.
+        Can be a scalar or an array matching the shape of `data`.
     """
 
-    zscores: np.ndarray
+    data: np.ndarray
     loc: float
     scale: float | np.ndarray
 
@@ -32,33 +46,35 @@ class ZScoreResult:
 def running_filter(
     array: np.ndarray,
     window: int,
-    method: str = "mean",
+    method: Literal["mean", "median"] = "mean",
 ) -> np.ndarray:
     """
     Calculate the running filter of an array.
 
+    Applies a sliding window filter to the input array using the specified method.
+
     Parameters
     ----------
-    array : numpy.ndarray
-        The array to calculate the running filter of.
+    array : ndarray
+        The input array to filter.
     window : int
-        The window size of the filter.
-    method : str, optional
-        The method to use for the filter, by default "mean".
+        The size of the sliding window.
+    method : {"mean", "median"}, optional
+        The filtering method to use, by default "mean".
 
     Returns
     -------
-    numpy.ndarray
-        The running filter of the array.
+    ndarray
+        The filtered array with the same shape as the input array.
 
     Raises
     ------
     ValueError
-        If the filter function is not "mean" or "median".
+        If the ``method`` is not supported.
 
     Notes
     -----
-    Window edges are handled by reflecting about the edges.
+    Window edges are handled by reflecting about the edges of the input array.
 
     """
     filter_methods: dict[str, Callable[[np.ndarray, int], np.ndarray]] = {
@@ -78,14 +94,18 @@ def running_filter(
     return filtered_ar[window - 1 :]
 
 
-def estimate_loc(array: np.ndarray, method: str = "median") -> float:
-    """Estimate the location of an array.
+def estimate_loc(
+    array: np.ndarray,
+    method: LocMethodType = "median",
+) -> float:
+    """
+    Estimate the location (central tendency) of an array.
 
     Parameters
     ----------
-    array : numpy.ndarray
-        The array to estimate the location of.
-    method : str, optional
+    array : ndarray
+        The input array to estimate the location of.
+    method : {"median", "mean"}, optional
         The method to use for estimating the location, by default "median".
 
     Returns
@@ -96,7 +116,7 @@ def estimate_loc(array: np.ndarray, method: str = "median") -> float:
     Raises
     ------
     ValueError
-        If the method is not supported
+        If the ``array`` is empty or if the ``method`` is not supported.
     """
     loc_methods: dict[str, Callable[[np.ndarray], float]] = {
         "median": np.median,
@@ -114,38 +134,47 @@ def estimate_loc(array: np.ndarray, method: str = "median") -> float:
     return loc_func(array)
 
 
-def estimate_scale(array: np.ndarray, method: str = "mad") -> float | np.ndarray:
-    """Estimate the scale or standard deviation of an array.
+def estimate_scale(
+    array: np.ndarray,
+    method: ScaleMethodType = "mad",
+) -> float | np.ndarray:
+    """
+    Estimate the scale (variability) or standard deviation of an array.
 
     Parameters
     ----------
-    array : numpy.ndarray
-        The array to estimate the scale of.
-    method : str, optional
+    array : ndarray
+        The input array to estimate the scale of.
+    method : {"iqr", "mad", "doublemad", "diffcov", "biweight", "qn",
+        "sn", "gapper"}, optional
+
         The method to use for estimating the scale, by default "mad".
+
+        - `iqr`: Normalized Inter-quartile Range.
+        - `mad`: Median Absolute Deviation.
+        - `doublemad`: Double MAD.
+        - `diffcov`: Difference Covariance
+        - `biweight`: Biweight Midvariance
+        - `qn`: Normalized Qn scale
+        - `sn`: Normalized Sn scale
+        - `gapper`: Gapper Estimator
 
     Returns
     -------
-    float | numpy.ndarray
-        The estimated scale of the array.
+    float | ndarray
+        The estimated scale of the array. If the method is "doublemad", the
+        output is an array of the same shape as the input array.
 
     Raises
     ------
     ValueError
-        If the method is not supported or if the array is empty.
+        If the ``array`` is empty or if the ``method`` is not supported.
 
-    Notes
-    -----
-    https://en.wikipedia.org/wiki/Robust_measures_of_scale
+    References
+    ----------
+    .. [1] Wikipedia, "Robust measures of scale",
+        https://en.wikipedia.org/wiki/Robust_measures_of_scale
 
-    Following methods are supported:
-    - "iqr": Normalized Inter-quartile Range
-    - "mad": Median Absolute Deviation
-    - "diffcov": Difference Covariance
-    - "biweight": Biweight Midvariance
-    - "qn": Normalized Qn scale
-    - "sn": Normalized Sn scale
-    - "gapper": Gapper Estimator
     """
     scale_methods: dict[str, Callable[[np.ndarray], float | np.ndarray]] = {
         "iqr": _scale_iqr,
@@ -169,41 +198,53 @@ def estimate_scale(array: np.ndarray, method: str = "mad") -> float | np.ndarray
     return scale_func(array)
 
 
-def zscore(
+def estimate_zscore(
     array: np.ndarray,
-    loc_method: str = "median",
-    scale_method: str = "mad",
+    loc_method: LocMethodType | Literal["norm"] = "median",
+    scale_method: ScaleMethodType | Literal["norm"] = "mad",
 ) -> ZScoreResult:
-    """Calculate robust Z-scores of an array.
+    """
+    Calculate robust Z-scores of an array.
 
     Parameters
     ----------
-    array : numpy.ndarray
-        The array to calculate the Z-score of.
-    loc_method : str, optional
+    array : ndarray
+        The input array to calculate the Z-score of.
+    loc_method : {"median", "mean", "norm"}, optional
         The method to use for estimating the location, by default "median".
-    scale_method : str, optional
+
+        Use "norm" to set the location to 0.
+    scale_method : {"mad", "iqr", "doublemad", "diffcov", "biweight", "qn", "sn",
+        "gapper", "norm"}, optional
+
         The method to use for estimating the scale, by default "mad".
+
+        Use "norm" to set the scale to 1.
 
     Returns
     -------
     ZScoreResult
-        The robust Z-scores of the array.
+        A container with the Z-scores, estimated location, and scale.
 
     Raises
     ------
     ValueError
-        If the location or scale method is not supported.
+        If the ``loc_method`` or ``scale_method`` is not supported.
+
+    See Also
+    --------
+    estimate_loc, estimate_scale
     """
-    loc = estimate_loc(array, loc_method)
-    scale = estimate_scale(array, scale_method)
+    loc = 0 if loc_method == "norm" else estimate_loc(array, loc_method)
+    scale = 1 if scale_method == "norm" else estimate_scale(array, scale_method)
     diff = array - loc
     zscores = np.divide(diff, scale, out=np.zeros_like(diff), where=scale != 0)
-    return ZScoreResult(zscores=zscores, loc=loc, scale=scale)
+    return ZScoreResult(data=zscores, loc=loc, scale=scale)
 
 
 def _scale_iqr(array: np.ndarray) -> float:
-    """Calculate the normalized Inter-quartile Range (IQR) scale of an array.
+    """
+    Calculate the normalized Inter-quartile Range (IQR) scale of an array.
 
     Parameters
     ----------
@@ -222,7 +263,8 @@ def _scale_iqr(array: np.ndarray) -> float:
 
 
 def _scale_mad(array: np.ndarray) -> float:
-    """Calculate the Median Absolute Deviation (MAD) scale of an array.
+    """
+    Calculate the Median Absolute Deviation (MAD) scale of an array.
 
     Parameters
     ----------
@@ -234,9 +276,10 @@ def _scale_mad(array: np.ndarray) -> float:
     float
         The MAD scale of the array.
 
-    Notes
-    -----
-    https://www.ibm.com/docs/en/cognos-analytics/12.0.0?topic=terms-modified-z-score
+    References
+    ----------
+    .. [1] IBM, "Modified Z-score",
+        https://www.ibm.com/docs/en/cognos-analytics/12.0.0?topic=terms-modified-z-score
     """
     norm = 0.6744897501960817  # scipy.stats.norm.ppf(0.75)
     norm_aad = np.sqrt(2 / np.pi)
@@ -248,7 +291,8 @@ def _scale_mad(array: np.ndarray) -> float:
 
 
 def _scale_doublemad(array: np.ndarray) -> np.ndarray:
-    """Calculate the Double MAD scale of an array.
+    """
+    Calculate the Double MAD scale of an array.
 
     Parameters
     ----------
@@ -260,11 +304,12 @@ def _scale_doublemad(array: np.ndarray) -> np.ndarray:
     np.ndarray
         The Double MAD scale of the array.
 
-    Notes
-    -----
-    The Double MAD is defined as:
-    https://eurekastatistics.com/using-the-median-absolute-deviation-to-find-outliers/
-    https://aakinshin.net/posts/harrell-davis-double-mad-outlier-detector/
+    References
+    ----------
+    .. [1] Eureka Statistics, "Using the Median Absolute Deviation to Find Outliers",
+        https://eurekastatistics.com/using-the-median-absolute-deviation-to-find-outliers/
+    .. [2] A. Akinshin, "Harrell-Davis Double MAD Outlier Detector",
+        https://aakinshin.net/posts/harrell-davis-double-mad-outlier-detector/
 
     """
     norm = 0.6744897501960817  # scipy.stats.norm.ppf(0.75)
@@ -287,7 +332,8 @@ def _scale_doublemad(array: np.ndarray) -> np.ndarray:
 
 
 def _scale_diffcov(array: np.ndarray) -> float:
-    """Calculate the Difference Covariance scale of an array.
+    """
+    Calculate the Difference Covariance scale of an array.
 
     Parameters
     ----------
@@ -304,7 +350,8 @@ def _scale_diffcov(array: np.ndarray) -> float:
 
 
 def _scale_biweight(array: np.ndarray) -> float:
-    """Calculate the Biweight Midvariance scale of an array.
+    """
+    Calculate the Biweight Midvariance scale of an array.
 
     Parameters
     ----------
@@ -320,7 +367,8 @@ def _scale_biweight(array: np.ndarray) -> float:
 
 
 def _scale_qn(array: np.ndarray) -> float:
-    """Calculate the Normalized Qn scale of an array.
+    """
+    Calculate the Normalized Qn scale of an array.
 
     Parameters
     ----------
@@ -342,7 +390,8 @@ def _scale_qn(array: np.ndarray) -> float:
 
 
 def _scale_sn(array: np.ndarray) -> float:
-    """Calculate the Normalized Sn scale of an array.
+    """
+    Calculate the Normalized Sn scale of an array.
 
     Parameters
     ----------
@@ -359,7 +408,8 @@ def _scale_sn(array: np.ndarray) -> float:
 
 
 def _scale_gapper(array: np.ndarray) -> float:
-    """Calculate the Gapper Estimator scale of an array.
+    """
+    Calculate the Gapper Estimator scale of an array.
 
     Parameters
     ----------
@@ -378,71 +428,74 @@ def _scale_gapper(array: np.ndarray) -> float:
 
 
 class ChannelStats:
-    def __init__(self, nchans: int, nsamps: int) -> None:
-        """Central central moments for filterbank channels in one pass.
+    """
+    A class to compute the central moments of filterbank data in one pass.
 
-        Parameters
-        ----------
-        nchans : int
-            Number of channels in the data.
-        nsamps : int
-            Number of samples in the data.
+    Parameters
+    ----------
+    nchans : int
+        Number of channels in the data.
+    nsamps : int
+        Number of samples in the data.
 
-        Notes
-        -----
-        The algorithm is numerically stable and accurate:
+    References
+    ----------
+    .. [1] Wikipedia, "Algorithms for calculating variance",
         https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+    .. [2] John D. Cook, "Skewness and kurtosis formulas for normal distributions",
         https://www.johndcook.com/blog/skewness_kurtosis/
+    .. [3] Pebay, Philippe P., "One-Pass covariances and Statistical Moments",
         https://doi.org/10.2172/1028931
-        """
+    """
+
+    def __init__(self, nchans: int, nsamps: int) -> None:
         self._nchans = nchans
         self._nsamps = nsamps
-
         self._moments = np.zeros(nchans, dtype=kernels.moments_dtype)
 
     @property
     def moments(self) -> np.ndarray:
-        """:class:`~numpy.ndarray`: Central moments of the data."""
+        """:class:`~numpy.ndarray`: Get the central moments of the data."""
         return self._moments
 
     @property
     def nchans(self) -> int:
-        """int: Get the number of channels."""
+        """:obj:`int`: Get the number of channels."""
         return self._nchans
 
     @property
     def nsamps(self) -> int:
-        """int: Get the number of samples."""
+        """:obj:`int`: Get the number of samples."""
         return self._nsamps
 
     @property
     def maxima(self) -> np.ndarray:
-        """numpy.ndarray: Get the maximum value of each channel."""
+        """:class:`~numpy.ndarray`: Get the maximum value of each channel."""
         return self._moments["max"]
 
     @property
     def minima(self) -> np.ndarray:
-        """numpy.ndarray: Get the minimum value of each channel."""
+        """:class:`~numpy.ndarray`: Get the minimum value of each channel."""
         return self._moments["min"]
 
     @property
     def mean(self) -> np.ndarray:
-        """numpy.ndarray: Get the mean of each channel."""
+        """:class:`~numpy.ndarray`: Get the mean of each channel."""
         return self._moments["m1"]
 
     @property
     def var(self) -> np.ndarray:
-        """numpy.ndarray: Get the variance of each channel."""
+        """:class:`~numpy.ndarray`: Get the variance of each channel."""
         return self._moments["m2"] / self.nsamps
 
     @property
     def std(self) -> np.ndarray:
-        """numpy.ndarray: Get the standard deviation of each channel."""
+        """:class:`~numpy.ndarray`: Get the standard deviation of each channel."""
         return np.sqrt(self.var)
 
     @property
     def skew(self) -> np.ndarray:
-        """numpy.ndarray: Get the skewness of each channel."""
+        """:class:`~numpy.ndarray`: Get the skewness of each channel."""
         return np.divide(
             self._moments["m3"],
             np.power(self._moments["m2"], 1.5),
@@ -452,7 +505,7 @@ class ChannelStats:
 
     @property
     def kurtosis(self) -> np.ndarray:
-        """numpy.ndarray: Get the kurtosis of each channel."""
+        """:class:`~numpy.ndarray`: Get the kurtosis of each channel."""
         return (
             np.divide(
                 self._moments["m4"],
@@ -468,8 +521,23 @@ class ChannelStats:
         self,
         array: np.ndarray,
         start_index: int,
-        mode: str = "basic",
+        mode: Literal["basic", "full"] = "basic",
     ) -> None:
+        """
+        Update the central moments of the data with new samples.
+
+        Parameters
+        ----------
+        array : ndarray
+            The input array to update the moments with.
+        start_index : int
+            The starting time (sample) index of the data.
+        mode : {"basic", "full"}, optional
+            The mode to use for computing the moments, by default "basic".
+
+            - "basic": Compute the moments upto 2nd order (variance).
+            - "full": Compute the moments upto 4th order (kurtosis).
+        """
         if mode == "basic":
             kernels.compute_online_moments_basic(
                 array,
@@ -480,7 +548,8 @@ class ChannelStats:
             kernels.compute_online_moments(array, self._moments, start_index)
 
     def __add__(self, other: ChannelStats) -> ChannelStats:
-        """Add two ChannelStats objects together as if all the data belonged to one.
+        """
+        Add two ChannelStats objects together as if all the data belonged to one.
 
         Parameters
         ----------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,32 +3,39 @@ import pytest
 from matplotlib import pyplot as plt
 
 from sigpyproc.core.filters import MatchedFilter, Template
+from sigpyproc.core.stats import ZScoreResult
 
 
 @pytest.fixture(scope="module", autouse=True)
 def random_data() -> np.ndarray:
     rng = np.random.default_rng(42)
-    return rng.normal(loc=0, scale=1, size=1000)
+    return rng.normal(loc=0, scale=1, size=1000).astype(np.float32)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def pulse_data() -> np.ndarray:
     rng = np.random.default_rng(42)
-    x = np.linspace(-10, 10, 1000)
+    x = np.linspace(-10, 10, 1000, dtype=np.float32)
     pulse = np.exp(-0.5 * (x**2))
-    noise = rng.normal(0, 0.1, 1000)
+    noise = rng.normal(0, 0.1, 1000).astype(np.float32)
     return pulse + noise
 
 
 class TestMatchedFilter:
     def test_initialization(self, pulse_data: np.ndarray) -> None:
-        mf = MatchedFilter(pulse_data)
+        mf = MatchedFilter(pulse_data, temp_kind="boxcar")
         assert isinstance(mf, MatchedFilter)
         assert mf.data.shape == pulse_data.shape
         assert mf.temp_kind == "boxcar"
-        assert mf.noise_method == "iqr"
+        assert isinstance(mf.zscores, ZScoreResult)
         with pytest.raises(ValueError):
-            MatchedFilter(np.zeros((2, 2)))
+            MatchedFilter(np.zeros((2, 2), dtype=np.float32))
+
+    def test_fails(self, pulse_data: np.ndarray) -> None:
+        with pytest.raises(ValueError):
+            MatchedFilter(pulse_data, temp_kind="gaussian", spacing_factor=1)
+        with pytest.raises(ValueError):
+            MatchedFilter(np.ones(10), nbins_max=20)
 
     def test_convolution(self, pulse_data: np.ndarray) -> None:
         mf = MatchedFilter(pulse_data)
@@ -46,13 +53,13 @@ class TestMatchedFilter:
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
 
-    @pytest.mark.parametrize(("nbins_max", "spacing_factor"), [(16, 1.2), (64, 2.0)])
-    def test_width_spacing(self, nbins_max: int, spacing_factor: float) -> None:
-        widths = MatchedFilter.get_width_spacing(nbins_max, spacing_factor)
+    @pytest.mark.parametrize(("size_max", "spacing_factor"), [(16, 1.2), (64, 2.0)])
+    def test_get_box_width_spacing(self, size_max: int, spacing_factor: float) -> None:
+        widths = MatchedFilter.get_box_width_spacing(size_max, spacing_factor)
         assert isinstance(widths, np.ndarray)
         assert widths[0] == 1
         assert np.all(np.diff(widths) > 0)
-        assert widths[-1] <= nbins_max
+        assert widths[-1] <= size_max
 
 
 class TestTemplate:
@@ -62,7 +69,7 @@ class TestTemplate:
         assert isinstance(temp, Template)
         assert temp.kind == "boxcar"
         assert temp.width == width
-        assert temp.size == width
+        assert temp.data.size == width
         assert str(temp) == repr(temp)
         assert "Template" in str(temp)
 
@@ -71,24 +78,46 @@ class TestTemplate:
         temp = Template.gen_gaussian(width, extent)
         assert isinstance(temp, Template)
         assert temp.kind == "gaussian"
-        assert temp.width == width
-        assert temp.size == int(np.ceil(extent * width / 2.355) * 2 + 1)
+        np.testing.assert_equal(temp.width, width)
+        expected_size = int(np.ceil(extent * width / 2.355) * 2 + 1)
+        np.testing.assert_equal(temp.data.size, expected_size)
 
     @pytest.mark.parametrize(("width", "extent"), [(1.0, 3.5), (5.0, 4.0)])
     def test_lorentzian(self, width: float, extent: float) -> None:
         temp = Template.gen_lorentzian(width, extent)
         assert isinstance(temp, Template)
         assert temp.kind == "lorentzian"
-        assert temp.width == width
-        assert temp.size == int(np.ceil(extent * width / 2.355) * 2 + 1)
+        np.testing.assert_equal(temp.width, width)
+        expected_size = int(np.ceil(extent * width / 2.355) * 2 + 1)
+        np.testing.assert_equal(temp.data.size, expected_size)
 
-    def test_get_padded(self) -> None:
-        temp = Template.gen_boxcar(5)
-        padded = temp.get_padded(10)
-        assert len(padded) == 10
-        assert np.all(padded[5:] == 0)
+    def test_fails(self) -> None:
         with pytest.raises(ValueError):
-            temp.get_padded(3)
+            Template.gen_boxcar(-1)
+        with pytest.raises(ValueError):
+            Template.gen_gaussian(-1)
+        with pytest.raises(ValueError):
+            Template.gen_lorentzian(-1)
+        with pytest.raises(ValueError):
+            Template(np.array([]), 5, 2)
+        with pytest.raises(ValueError):
+            Template(np.zeros((10, 10)), 5, 2)
+        with pytest.raises(ValueError):
+            Template(np.zeros(10), 5, 20)
+
+    def test_get_model(self) -> None:
+        temp = Template.gen_boxcar(5)
+        model = temp.get_model(peak_bin=10, nbins=20)
+        np.testing.assert_equal(model.size, 20)
+        assert np.all(model[10:15] > 0)
+
+    def test_get_on_pulse(self) -> None:
+        temp = Template.gen_boxcar(5)
+        on_pulse = temp.get_on_pulse(peak_bin=10, nbins=20)
+        np.testing.assert_equal(on_pulse, (10, 15))
+        temp = Template.gen_gaussian(5)
+        on_pulse = temp.get_on_pulse(peak_bin=10, nbins=20)
+        np.testing.assert_equal(on_pulse, (5, 15))
 
     def test_plot(self) -> None:
         temp = Template.gen_gaussian(5)
@@ -99,7 +128,7 @@ class TestTemplate:
 
 @pytest.mark.parametrize("temp_kind", ["boxcar", "gaussian", "lorentzian"])
 def test_end_to_end(pulse_data: np.ndarray, temp_kind: str) -> None:
-    mf = MatchedFilter(pulse_data, temp_kind=temp_kind)
+    mf = MatchedFilter(pulse_data, temp_kind=temp_kind)  # type: ignore[arg-type]
     assert mf.snr > 5  # Assuming a strong pulse
     assert 450 < mf.peak_bin < 550  # Assuming pulse is roughly in the middle
-
+    assert isinstance(mf.best_model, np.ndarray)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -126,7 +126,7 @@ class TestZScore:
         loc_method: str,
         scale_method: str,
     ) -> None:
-        zscore_re = stats.zscore(
+        zscore_re = stats.estimate_zscore(
             random_normal,
             loc_method=loc_method,
             scale_method=scale_method,
@@ -134,30 +134,30 @@ class TestZScore:
         assert isinstance(zscore_re, stats.ZScoreResult)
         np.testing.assert_almost_equal(5, zscore_re.loc, decimal=1)
         np.testing.assert_allclose(2, zscore_re.scale, atol=0.3)
-        assert zscore_re.zscores.shape == random_normal.shape
-        np.testing.assert_almost_equal(0, zscore_re.zscores.mean(), decimal=1)
-        np.testing.assert_almost_equal(1, zscore_re.zscores.std(), decimal=1)
+        assert zscore_re.data.shape == random_normal.shape
+        np.testing.assert_almost_equal(0, zscore_re.data.mean(), decimal=1)
+        np.testing.assert_almost_equal(1, zscore_re.data.std(), decimal=1)
 
     def test_zscore_double_mad(self, random_normal: np.ndarray) -> None:
-        zscore_re = stats.zscore(random_normal, scale_method="doublemad")
+        zscore_re = stats.estimate_zscore(random_normal, scale_method="doublemad")
         assert isinstance(zscore_re, stats.ZScoreResult)
         np.testing.assert_almost_equal(5, zscore_re.loc, decimal=1)
         assert isinstance(zscore_re.scale, np.ndarray)
         np.testing.assert_allclose(2, zscore_re.scale.mean(), atol=0.3)
         assert zscore_re.scale.shape == random_normal.shape
-        assert zscore_re.zscores.shape == random_normal.shape
-        np.testing.assert_almost_equal(0, zscore_re.zscores.mean(), decimal=1)
-        np.testing.assert_almost_equal(1, zscore_re.zscores.std(), decimal=1)
+        assert zscore_re.data.shape == random_normal.shape
+        np.testing.assert_almost_equal(0, zscore_re.data.mean(), decimal=1)
+        np.testing.assert_almost_equal(1, zscore_re.data.std(), decimal=1)
 
     def test_zscore_empty(self) -> None:
         with pytest.raises(ValueError):
-            stats.zscore(np.array([]))
+            stats.estimate_zscore(np.array([]))
 
     def test_zscore_invalid(self, random_normal: np.ndarray) -> None:
         with pytest.raises(ValueError):
-            stats.zscore(random_normal, loc_method="invalid")
+            stats.estimate_zscore(random_normal, loc_method="invalid")
         with pytest.raises(ValueError):
-            stats.zscore(random_normal, scale_method="invalid")
+            stats.estimate_zscore(random_normal, scale_method="invalid")
 
 
 class TestRunningFilter:


### PR DESCRIPTION
Matched filter:
- Astropy kernels are not helpful. Now, custom kernels are used, which gives more control over normalization.
- Astropy `convolve_fft` is too complicated. We need a simple FFT-based convolution, so using numpy FFT functions with `numba` ([rocket-fft](https://github.com/styfenschaer/rocket-fft)).
- In principle, this is based on [spyden](https://bitbucket.org/vmorello/spyden/src/master/). Templates are also mean-subtracted to remove bias. Hopefully, this is correct!
- It will be useful for the pulsar module + upcoming simulation module.