### PR TITLE
Added MWA telescope and machine IDs

### DIFF
--- a/sigpyproc/io/sigproc.py
+++ b/sigpyproc/io/sigproc.py
@@ -51,6 +51,7 @@ telescope_ids = bidict(
         "LOFAR": 11,
         "VLA": 12,
         "CHIME": 20,
+        "MWA": 30,
         "MeerKAT": 64,
     },
 )
@@ -71,6 +72,9 @@ machine_ids = bidict(
         "COBALT": 11,
         "GMRTNEW": 14,
         "CHIME": 20,
+        "MWA-VCS": 30,
+        "MWAX-VCS": 31,
+        "MWAX-RTB": 32,
     },
 )
 


### PR DESCRIPTION
We have recently begun producing SIGPROC filterbank output for some use cases with the MWA. As such we have selected telescope and machine IDs, which have been added to [PRESTO](https://github.com/scottransom/presto/pull/190) and DSPSR accordingly. The telescope ID is 30, and there are three machine IDs (30, 31, 32) representing different generations of the voltage capture system. I have added these to sigpyproc3 so we can make use some of the convenient tools that you have provided.