### PR TITLE
Robust sigproc header parsing

### DIFF
--- a/sigpyproc/header.py
+++ b/sigpyproc/header.py
@@ -485,7 +485,7 @@ class Header:
         """
         header = self.to_dict()
         sig_header = {
-            key: value for key, value in header.items() if key in sigproc.header_keys
+            key: value for key, value in header.items() if key in sigproc.SIGPROC_SCHEMA
         }
         hdr_update = {
             "data_type": params.data_types.inverse[sig_header["data_type"]],
@@ -709,7 +709,7 @@ class Header:
         Header
             Observational metadata.
         """
-        header = sigproc.parse_header_multi(
+        header, sinfo = sigproc.parse_header_multi(
             filenames,
             check_contiguity=check_contiguity,
         )
@@ -737,7 +737,7 @@ class Header:
         header_check = {
             key: value for key, value in header.items() if key in attrs.fields_dict(cls)
         }
-        return cls(**header_check)
+        return cls(**header_check, stream_info=sinfo)
 
     @classmethod
     def from_pfits(cls, filename: str) -> Header:

--- a/sigpyproc/io/sigproc.py
+++ b/sigpyproc/io/sigproc.py
@@ -655,9 +655,6 @@ def _compute_nsamples(header: dict[str, int | float | str]) -> int:
     nsamples_from_file = (8 * datalen) // nbits // nchans
 
     if "nsamples" in header:
-        # Header-declared value: treat as an upper-bound hint, not gospel.
-        # A writer may declare more samples than were actually flushed
-        # (crashed mid-write, reserved space, etc.), so we take the min.
         nsamples_declared = int(header["nsamples"])
         if nsamples_declared != nsamples_from_file:
             logger.warning(

--- a/sigpyproc/io/sigproc.py
+++ b/sigpyproc/io/sigproc.py
@@ -1,45 +1,79 @@
 from __future__ import annotations
 
 import struct
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
-import attrs
 import numpy as np
 from astropy import units
 from astropy.coordinates import SkyCoord
 from bidict import bidict
 
-from sigpyproc.utils import validate_path
+from sigpyproc.utils import get_logger, validate_path
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-header_keys = {
-    "signed": "b",
-    "telescope_id": "I",
-    "ibeam": "I",
-    "nbeams": "I",
-    "refdm": "d",
-    "nifs": "I",
-    "nchans": "I",
-    "foff": "d",
-    "fch1": "d",
-    "nbits": "I",
-    "tsamp": "d",
-    "tstart": "d",
-    "src_dej": "d",
-    "src_raj": "d",
-    "za_start": "d",
-    "az_start": "d",
-    "source_name": "str",
-    "rawdatafile": "str",
-    "data_type": "I",
-    "machine_id": "I",
-    "barycentric": "I",
-    "pulsarcentric": "I",
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class HeaderField:
+    fmt: struct.Struct | None  # None for string fields
+    doc: str
+
+
+_UINT = struct.Struct("<I")  # 4 bytes, unsigned int
+_DOUBLE = struct.Struct("<d")  # 8 bytes, double
+_BYTE = struct.Struct("b")  # 1 byte, signed byte
+
+SIGPROC_SCHEMA: dict[str, HeaderField] = {
+    "telescope_id": HeaderField(fmt=_UINT, doc="Numeric telescope identifier"),
+    "machine_id": HeaderField(fmt=_UINT, doc="Numeric machine identifier"),
+    "data_type": HeaderField(fmt=_UINT, doc="Numeric data type identifier"),
+    "rawdatafile": HeaderField(fmt=None, doc="Name of the original data file"),
+    "source_name": HeaderField(fmt=None, doc="Name of the observed source"),
+    "barycentric": HeaderField(
+        fmt=_UINT, doc="Whether the data are barycentric (1) or otherwise (0)"
+    ),
+    "pulsarcentric": HeaderField(
+        fmt=_UINT, doc="Whether the data are pulsarcentric (1) or otherwise (0)"
+    ),
+    "az_start": HeaderField(
+        fmt=_DOUBLE, doc="Telescope azimuth at start of scan (degrees)"
+    ),
+    "za_start": HeaderField(
+        fmt=_DOUBLE, doc="Telescope zenith angle at start of scan (degrees)"
+    ),
+    "src_raj": HeaderField(
+        fmt=_DOUBLE,
+        doc="Right ascension (J2000) of source (HHMMSS.S)",
+    ),
+    "src_dej": HeaderField(
+        fmt=_DOUBLE,
+        doc="Declination of source (DDMMSS.S)",
+    ),
+    "tstart": HeaderField(fmt=_DOUBLE, doc="Time stamp (MJD) of first sample"),
+    "tsamp": HeaderField(fmt=_DOUBLE, doc="Time interval between samples (s)"),
+    "nbits": HeaderField(fmt=_UINT, doc="Number of bits per time sample"),
+    "nsamples": HeaderField(
+        fmt=_UINT, doc="Number of time samples in the data file (rarely used)"
+    ),
+    "fch1": HeaderField(
+        fmt=_DOUBLE, doc="Centre frequency (MHz) of first filterbank channel"
+    ),
+    "foff": HeaderField(fmt=_DOUBLE, doc="Filterbank channel bandwidth (MHz)"),
+    "nchans": HeaderField(fmt=_UINT, doc="Number of frequency channels"),
+    "nifs": HeaderField(fmt=_UINT, doc="Number of seperate IF channels"),
+    "refdm": HeaderField(fmt=_DOUBLE, doc="Reference Dispersion Measure (pc/cm^3)"),
+    "period": HeaderField(fmt=_DOUBLE, doc="Pulsar folding period (s)"),
+    "signed": HeaderField(fmt=_BYTE, doc="Sign convention of 8-bit data samples"),
+    "ibeam": HeaderField(fmt=_UINT, doc="Beam number of the observation"),
+    "nbeams": HeaderField(fmt=_UINT, doc="Number of beams in the observation"),
 }
 """Header keys recognised by the sigproc package."""
+
 
 telescope_ids = bidict(
     {
@@ -91,7 +125,7 @@ machine_ids = bidict(
 """Machine IDs recognised by the sigproc package."""
 
 
-@attrs.define(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class FileInfo:
     """Class to handle individual file information."""
 
@@ -108,17 +142,22 @@ class FileInfo:
         return self.tstart + ((self.nsamples - 1) * self.tsamp) / 86400
 
     @classmethod
-    def from_dict(cls, info: dict) -> FileInfo:
-        """Create FileInfo object from a dictionary."""
-        info_filtered = {key: info[key] for key in attrs.fields_dict(cls)}
-        return cls(**info_filtered)
+    def from_dict(cls, info: dict[str, int | float | str]) -> FileInfo:
+        return cls(
+            filename=str(info["filename"]),
+            hdrlen=int(info["hdrlen"]),
+            datalen=int(info["datalen"]),
+            nsamples=int(info["nsamples"]),
+            tstart=float(info["tstart"]),
+            tsamp=float(info["tsamp"]),
+        )
 
 
-@attrs.define(frozen=True)
+@dataclass(slots=True)
 class StreamInfo:
     """Class to handle stream information as a list of FileInfo objects."""
 
-    entries: list[FileInfo] = attrs.Factory(list)
+    entries: list[FileInfo] = field(default_factory=list)
 
     @property
     def cumsum_datalens(self) -> np.ndarray:
@@ -136,12 +175,9 @@ class StreamInfo:
 
     def add_entry(self, finfo: FileInfo) -> None:
         """Add a FileInfo entry to the StreamInfo object."""
-        if not isinstance(finfo, FileInfo):
-            msg = f"Input must be a FileInfo object, got {type(finfo)}"
-            raise TypeError(msg)
         self.entries.append(finfo)
 
-    def get_combined(self, key: str) -> int:
+    def get_combined(self, key: str) -> int | float:
         """Get the combined value of a key for all entries."""
         return sum(self.get_info_list(key))
 
@@ -180,32 +216,56 @@ def edit_header(filename: str | Path, key: str, value: float | str) -> None:
        It is up to the user to be responsible with this function, as it will directly
        change the file on which it is being operated.
     """
-    if key not in header_keys:
+    if key not in SIGPROC_SCHEMA:
         msg = f"Key '{key}' is not a valid sigproc key."
         raise ValueError(msg)
     header = parse_header(filename)
-    if key == "source_name" and isinstance(value, str):
-        oldlen = len(header["source_name"])
-        value = value[:oldlen] + " " * (oldlen - len(value))
+    # nsamples is always injected by parse_header (computed), but may or may
+    # not have existed in the original binary header. We must not encode it
+    # unless it was genuinely there — otherwise we silently grow the header.
+    nsamples_in_file = _nsamples_in_binary_header(filename)
+    if key in ("source_name", "rawdatafile") and isinstance(value, str):
+        old_value = str(header.get(key, ""))
+        old_bytes = old_value.encode("ascii")  # existing header must already obey this
+        try:
+            new_bytes = value.encode("ascii")
+        except UnicodeEncodeError as exc:
+            msg = (
+                f"New value for '{key}' contains non-ASCII characters, which is "
+                f"not allowed."
+            )
+            raise ValueError(msg) from exc
+        oldlen = len(old_bytes)
+        newlen = len(new_bytes)
+        if newlen > oldlen:
+            logger.warning(
+                f"New value for '{key}' is too long ({newlen} bytes) to fit in "
+                f"existing header space ({oldlen} bytes). Value will be truncated.",
+            )
+            new_bytes = new_bytes[:oldlen]
+        # Pad shorter values
+        new_bytes = new_bytes.ljust(oldlen, b" ")
+        value = new_bytes.decode("ascii")
 
-    hdr = header.copy()
-    hdr.update({key: value})
-    new_hdr = encode_header(hdr)
+    header[key] = value
+    new_hdr = encode_header(header, allow_nsamples_overwrite=nsamples_in_file)
     filepath = validate_path(filename, writable=True)
-    if header["hdrlen"] == len(new_hdr):
-        with filepath.open("rb+") as fp:
-            fp.seek(0)
-            fp.write(new_hdr)
-    else:
-        msg = f"New header is too long/short for file {filename}"
+    if len(new_hdr) != int(header["hdrlen"]):
+        msg = (
+            f"New header length {len(new_hdr)} != original "
+            f"{header['hdrlen']} for file {filename}."
+        )
         raise ValueError(msg)
+    with filepath.open("rb+") as fp:
+        fp.seek(0)
+        fp.write(new_hdr)
 
 
 def parse_header_multi(
     filenames: str | Path | Sequence[str | Path],
     *,
     check_contiguity: bool = True,
-) -> dict:
+) -> tuple[dict, StreamInfo]:
     """Parse the metadata from Sigproc-style file/sequential files.
 
     Parameters
@@ -215,8 +275,8 @@ def parse_header_multi(
 
     Returns
     -------
-    dict
-        observational metadata
+    tuple[dict[str, float | int | str], StreamInfo]
+        observational metadata and stream info
 
     """
     if isinstance(filenames, str | Path):
@@ -233,63 +293,53 @@ def parse_header_multi(
         if check_contiguity and not sinfo.check_contiguity():
             msg = f"Files {filenames} are not contiguous"
             raise ValueError(msg)
-
-    header["stream_info"] = sinfo
-    header["nsamples"] = header["stream_info"].get_combined("nsamples")
-    return header
+    header["nsamples"] = sinfo.get_combined("nsamples")
+    return header, sinfo
 
 
-def parse_header(filename: str | Path) -> dict:
-    """
-    Parse the metadata from a single Sigproc-style filterbank file.
+def parse_header(filename: str | Path) -> dict[str, float | int | str]:
+    """Parse the metadata from a single Sigproc-style filterbank file.
 
     Parameters
     ----------
     filename : str | Path
-        Path to the sigproc filterbank file containing the header
+        Path to the sigproc filterbank file.
 
     Returns
     -------
-    dict
-        observational metadata
+    dict[str, float | int | str]
+        Observational metadata, plus computed keys.
 
     Raises
     ------
     OSError
-        If file header is not in sigproc format
+        If the file header is not in sigproc format, is empty, or is
+        truncated mid-header.
+    ValueError
+        If required keys (nbits, nchans) are missing or nsamples is zero.
     """
     filepath = validate_path(filename)
     with filepath.open("rb") as fp:
-        header: dict[str, float | str] = {}
-        try:
-            key = _read_string(fp)
-        except struct.error:
-            msg = f"File {filename} Header is not in sigproc format... Is file empty?."
-            raise OSError(msg) from None
-        if key != "HEADER_START":
-            msg = f"File {filename} Header is not in sigproc format."
-            raise OSError(msg)
-        while True:
-            key = _read_string(fp)
-            if key == "HEADER_END":
-                break
-
-            key_fmt = header_keys[key]
-            if key_fmt == "str":
-                header[key] = _read_string(fp)
-            else:
-                header[key] = struct.unpack(key_fmt, fp.read(struct.calcsize(key_fmt)))[
-                    0
-                ]
-        header["hdrlen"] = fp.tell()
+        header = _read_sigproc_header(fp, filepath)
         fp.seek(0, 2)
-        header["filelen"] = fp.tell()
-        header["datalen"] = int(header["filelen"]) - int(header["hdrlen"])
-        header["nsamples"] = (
-            8 * int(header["datalen"]) // int(header["nbits"]) // int(header["nchans"])
+        filelen = fp.tell()
+        header["filelen"] = filelen
+    hdrlen = int(header["hdrlen"])
+    datalen = filelen - hdrlen
+    if datalen < 0:
+        msg = (
+            f"{filepath}: File length {filelen} is smaller than header "
+            f"length {hdrlen}. File is likely corrupt."
         )
-        fp.seek(0)
-        header["filename"] = filepath.as_posix()
+        raise OSError(msg)
+    header["datalen"] = datalen
+    nsamples = _compute_nsamples(header)
+    if nsamples == 0:
+        logger.warning(
+            f"{filepath}: Computed nsamples is zero — data block may be empty."
+        )
+    header["nsamples"] = nsamples
+    header["filename"] = filepath.as_posix()
 
     return header
 
@@ -311,7 +361,7 @@ def match_header(header1: dict, header2: dict) -> None:
     """
     keys_nomatch = {"tstart", "rawdatafile"}
     for key, value in header1.items():
-        if key in keys_nomatch or key not in header_keys:
+        if key in keys_nomatch or key not in SIGPROC_SCHEMA:
             continue
         if value != header2[key]:
             msg = (
@@ -321,31 +371,38 @@ def match_header(header1: dict, header2: dict) -> None:
             raise ValueError(msg)
 
 
-def encode_header(header: dict) -> bytes:
-    """Get sigproc format header in binary format.
+def encode_header(
+    header: dict[str, int | float | str],
+    *,
+    allow_nsamples_overwrite: bool = False,
+) -> bytes:
+    """Encode sigproc header dict in binary format.
 
     Returns
     -------
     bytes
         header in binary format
     """
-    hdr_encoded = encode_key("HEADER_START")
+    hdr_encoded = _encode_string("HEADER_START")
 
-    for key, value in header.items():
-        if key not in header_keys:
+    # Deterministic ordering
+    for key in SIGPROC_SCHEMA:
+        # nsamples is legacy keyword and only for backward compatibility.
+        if key == "nsamples" and not allow_nsamples_overwrite:
             continue
-        hdr_encoded += encode_key(key, value=value, value_type=header_keys[key])
+        if key not in header:
+            continue
+        hdr_encoded += encode_key(key, value=header[key])
 
-    hdr_encoded += encode_key("HEADER_END")
+    hdr_encoded += _encode_string("HEADER_END")
     return hdr_encoded
 
 
 def encode_key(
     key: str,
     value: float | str | None = None,
-    value_type: str = "str",
 ) -> bytes:
-    """Encode given header key to a bytes string.
+    """Encode single SIGPROC header key to a bytes string.
 
     Parameters
     ----------
@@ -353,25 +410,25 @@ def encode_key(
         header key
     value : int or float or str, optional
         value of the header key, by default None
-    value_type : str, optional
-        type of the header key, by default "str"
 
     Returns
     -------
     bytes
         bytes encoded string
     """
+    field_bytes = _encode_string(key)
     if value is None:
-        return struct.pack("I", len(key)) + key.encode()
-
-    if value_type == "str" and isinstance(value, str):
-        return (
-            struct.pack("I", len(key))
-            + key.encode()
-            + struct.pack("I", len(value))
-            + value.encode()
-        )
-    return struct.pack("I", len(key)) + key.encode() + struct.pack(value_type, value)
+        return field_bytes
+    if key not in SIGPROC_SCHEMA:
+        msg = f"Unknown SIGPROC header key {key!r} cannot be encoded."
+        raise KeyError(msg)
+    field = SIGPROC_SCHEMA[key]
+    if field.fmt is None:
+        if not isinstance(value, str):
+            msg = f"Key {key!r} expects a string value, got {value}."
+            raise TypeError(msg)
+        return field_bytes + _encode_string(value)
+    return field_bytes + field.fmt.pack(value)
 
 
 def parse_radec(src_raj: float, src_dej: float) -> SkyCoord:
@@ -400,18 +457,212 @@ def parse_radec(src_raj: float, src_dej: float) -> SkyCoord:
     return SkyCoord(radec_str, unit=(units.hourangle, units.deg))
 
 
-def _read_string(fp: BinaryIO) -> str:
-    """Read the next sigproc-format string in the file.
+def _encode_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return _UINT.pack(len(encoded)) + encoded
+
+
+def _read_sigproc_header(fp: BinaryIO, filepath: Path) -> dict[str, int | float | str]:
+    header: dict[str, int | float | str] = {}
+    try:
+        key = _read_string(fp)
+    except (struct.error, UnicodeDecodeError, ValueError) as exc:
+        msg = f"{filepath}: Header is not in sigproc format... Is file empty?."
+        raise OSError(msg) from exc
+    if key != "HEADER_START":
+        msg = f"{filepath}: Header is not in sigproc format."
+        raise OSError(msg)
+    while True:
+        try:
+            key = _read_string(fp)
+        except (struct.error, UnicodeDecodeError, ValueError) as exc:
+            msg = (
+                f"{filepath}: Header truncated while reading key at "
+                f"byte offset {fp.tell()}."
+            )
+            raise OSError(msg) from exc
+        if key == "HEADER_END":
+            break
+        if key not in SIGPROC_SCHEMA:
+            # Unknown key: warn and attempt best-effort skip.
+            logger.warning(
+                f"{filepath}: Unknown header key {key} at offset {fp.tell()} — "
+                f"attempting skip.",
+            )
+            _skip_unknown_key(fp, filepath)
+            continue
+
+        field = SIGPROC_SCHEMA[key]
+        try:
+            if field.fmt is None:
+                header[key] = _read_string(fp)
+            else:
+                header[key] = _read_numeric(fp, field.fmt)
+        except (struct.error, UnicodeDecodeError, ValueError) as exc:
+            msg = (
+                f"{filepath}: Header truncated while reading value for key {key!r} "
+                f"at byte offset {fp.tell()}."
+            )
+            raise OSError(msg) from exc
+    header["hdrlen"] = fp.tell()
+    return header
+
+
+def _nsamples_in_binary_header(filename: str | Path) -> bool:
+    """Return True if 'nsamples' key is physically present in the binary header."""
+    filepath = validate_path(filename)
+    with filepath.open("rb") as fp:
+        _read_string(fp)  # HEADER_START — already validated upstream
+        while True:
+            key = _read_string(fp)
+            if key == "HEADER_END":
+                return False
+            if key == "nsamples":
+                return True
+            # Skip value — reuse existing field dispatch
+            field = SIGPROC_SCHEMA.get(key)
+            if field is None:
+                _skip_unknown_key(fp, filepath)
+            elif field.fmt is None:
+                _read_string(fp)
+            else:
+                fp.read(field.fmt.size)
+
+
+def _read_numeric(fp: BinaryIO, fmt: struct.Struct) -> int | float:
+    """Read and unpack a single fixed-width numeric value.
 
     Parameters
     ----------
-    fp : file object
-        file object to read from.
+    fp : BinaryIO
+        Open file object positioned at the numeric value.
+    fmt : struct.Struct
+        Precompiled struct describing the binary layout (must include endian).
 
     Returns
     -------
-    str
-        read value from the file
+    int | float
+        The unpacked numeric value.
+
+    Raises
+    ------
+    struct.error
+        If EOF is encountered before reading the required number of bytes.
     """
-    strlen = struct.unpack("I", fp.read(struct.calcsize("I")))[0]
-    return fp.read(strlen).decode()
+    data = fp.read(fmt.size)
+    if len(data) != fmt.size:
+        msg = (
+            f"EOF while reading numeric field: expected {fmt.size} bytes, "
+            f"got {len(data)}."
+        )
+        raise struct.error(msg)
+    return fmt.unpack(data)[0]
+
+
+def _read_string(fp: BinaryIO) -> str:
+    """Read a length-prefixed SIGPROC string: [uint32 length][raw bytes].
+
+    Strings in SIGPROC headers are short ASCII identifiers
+    (e.g., HEADER_START, source_name, etc.).
+
+    Raises
+    ------
+    struct.error
+        If EOF occurs while reading the length or string body.
+    ValueError
+        If the decoded length is implausible, indicating corruption
+        or file misalignment.
+    UnicodeDecodeError
+        If the string is not valid UTF-8/ASCII.
+    """
+    # Read length field
+    raw_len = fp.read(_UINT.size)
+    if len(raw_len) != _UINT.size:
+        msg = (
+            f"EOF while reading string length: expected {_UINT.size} bytes, "
+            f"got {len(raw_len)}."
+        )
+        raise struct.error(msg)
+
+    strlen = _UINT.unpack(raw_len)[0]
+    # SIGPROC strings are short (keywords, source names, etc.)
+    # A large value almost certainly indicates corruption.
+    if not (1 <= strlen <= 4096):
+        msg = f"Implausible string length {strlen}; file likely corrupt or misaligned."
+        raise ValueError(msg)
+
+    # Read string body
+    data = fp.read(strlen)
+    if len(data) != strlen:
+        msg = (
+            f"EOF while reading string body: expected {strlen} bytes, got {len(data)}."
+        )
+        raise struct.error(msg)
+    return data.decode("utf-8", errors="strict")
+
+
+def _skip_unknown_key(fp: BinaryIO, filepath: Path) -> None:
+    """Attempt to skip an unknown key's value by probing candidate sizes.
+
+    Strategy: save position, try each candidate Struct size, attempt
+    to read the *next* token as a valid string. If it looks like a
+    plausible sigproc key (known key or HEADER_END), commit; otherwise
+    restore and try the next size. If nothing works, raise OSError.
+    """
+    unknown_skip_structs = (_UINT, _DOUBLE, _BYTE)
+    start = fp.tell()
+    for candidate in unknown_skip_structs:
+        fp.seek(start)
+        data = fp.read(candidate.size)
+        if len(data) < candidate.size:
+            continue  # EOF — try smaller
+        # Peek at what would be the next key
+        peek_start = fp.tell()
+        try:
+            next_key = _read_string(fp)
+        except (struct.error, UnicodeDecodeError, ValueError):
+            continue
+        if next_key in SIGPROC_SCHEMA or next_key == "HEADER_END":
+            # Looks valid — rewind to peek_start so the main loop reads it
+            fp.seek(peek_start)
+            logger.debug(
+                f"Skipped unknown key value ({candidate.size} bytes) - next key "
+                f"is {next_key}."
+            )
+            return
+    msg = (
+        f"{filepath}: Cannot determine size of unknown header key value "
+        f"at offset {start}. File may be corrupt or use an unsupported extension."
+    )
+    raise OSError(msg)
+
+
+def _compute_nsamples(header: dict[str, int | float | str]) -> int:
+    """Compute the number of samples from parsed header."""
+    required_keys = frozenset({"nbits", "nchans", "datalen"})
+    missing = required_keys - header.keys()
+    if missing:
+        msg = f"Cannot compute nsamples: missing required header keys {missing}."
+        raise ValueError(msg)
+    nbits = int(header["nbits"])
+    nchans = int(header["nchans"])
+    datalen = int(header["datalen"])
+    if nbits <= 0 or nchans <= 0:
+        msg = f"Invalid header values: nbits={nbits}, nchans={nchans} (must be > 0)."
+        raise ValueError(msg)
+
+    # Samples derived purely from file size and header parameters.
+    nsamples_from_file = (8 * datalen) // nbits // nchans
+
+    if "nsamples" in header:
+        # Header-declared value: treat as an upper-bound hint, not gospel.
+        # A writer may declare more samples than were actually flushed
+        # (crashed mid-write, reserved space, etc.), so we take the min.
+        nsamples_declared = int(header["nsamples"])
+        if nsamples_declared != nsamples_from_file:
+            logger.warning(
+                f"Header nsamples={nsamples_declared} disagrees with file-derived "
+                f"nsamples={nsamples_from_file}. Using the smaller value.",
+            )
+        return min(nsamples_declared, nsamples_from_file)
+    return nsamples_from_file

--- a/sigpyproc/readers.py
+++ b/sigpyproc/readers.py
@@ -42,7 +42,7 @@ class FilReader(Filterbank):
     Notes
     -----
     To be considered as a Sigproc format filterbank file the header must only contain
-    keywords found in the :py:obj:`~sigpyproc.io.sigproc.header_keys` dictionary.
+    keywords found in the :py:obj:`~sigpyproc.io.sigproc.SIGPROC_SCHEMA` dictionary.
     """
 
     def __init__(

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -123,8 +123,8 @@ class TestFileReader:
     ) -> Generator[None, Any, None]:
         self.files = [filfile_8bit_1, filfile_8bit_2]
         self.mode = "r"
-        hdr = sigproc.parse_header_multi([Path(f) for f in self.files])
-        self.sinfo: sigproc.StreamInfo = hdr["stream_info"]
+        hdr, sinfo = sigproc.parse_header_multi([Path(f) for f in self.files])
+        self.sinfo = sinfo
         self.file_reader = fileio.FileReader(self.sinfo, self.mode, hdr["nbits"])
         yield
         self.file_reader.close()
@@ -227,8 +227,8 @@ class TestFileReaderUnpack:
     ) -> Generator[None, Any, None]:
         self.files = [filfile_2bit]
         self.mode = "r"
-        hdr = sigproc.parse_header_multi(self.files)
-        self.sinfo: sigproc.StreamInfo = hdr["stream_info"]
+        hdr, sinfo = sigproc.parse_header_multi(self.files)
+        self.sinfo = sinfo
         self.file_reader = fileio.FileReader(self.sinfo, self.mode, hdr["nbits"])
         yield
         self.file_reader.close()

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -68,7 +68,7 @@ class TestHeader:
         header = Header.from_sigproc(filfile_4bit)
         spphdr = header.to_sigproc()
         np.testing.assert_equal(spphdr["nchans"], header.nchans)
-        for key in sigproc.header_keys:
+        for key in sigproc.SIGPROC_SCHEMA:
             assert key in spphdr
 
     def test_to_string(self, filfile_4bit: str) -> None:
@@ -82,7 +82,13 @@ class TestHeader:
             outfilename = outfile.file_cur
         assert outfilename is not None
         out_header = Header.from_sigproc(outfilename)
-        np.testing.assert_equal(out_header.to_sigproc(), header.to_sigproc())
+        expected_dict = header.to_sigproc()
+        actual_dict = out_header.to_sigproc()
+        for key, value in expected_dict.items():
+            if key == "nsamples":
+                assert value != actual_dict[key]
+            else:
+                assert value == actual_dict[key]
 
     def test_from_inffile(self, inffile: str, inf_header: dict) -> None:
         infheader = Header.from_inffile(inffile)

--- a/tests/test_sigproc.py
+++ b/tests/test_sigproc.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import struct
 from pathlib import Path
+from typing import BinaryIO
 
 import numpy as np
 import pytest
@@ -11,73 +13,561 @@ from astropy.coordinates import SkyCoord
 from sigpyproc.io import sigproc
 
 
-class TestSigproc:
-    def test_read_string(self, tmpfile: str) -> None:
-        header = sigproc.encode_key("HEADER_START")
-        with Path(tmpfile).open(mode="wb") as wf:
-            wf.write(header)
-        with Path(tmpfile).open(mode="rb") as fp:
-            key = sigproc._read_string(fp)
-        assert key == "HEADER_START"
+class SigprocBuilder:
+    """sigproc-format byte streams for testing."""
 
+    _UINT = struct.Struct("<I")
+    _DOUBLE = struct.Struct("<d")
+    _BYTE = struct.Struct("b")
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def _write_string(self, s: str) -> SigprocBuilder:
+        encoded = s.encode("utf-8")
+        self._buf += self._UINT.pack(len(encoded)) + encoded
+        return self
+
+    def _write_uint(self, v: int) -> SigprocBuilder:
+        self._buf += self._UINT.pack(v)
+        return self
+
+    def _write_double(self, v: float) -> SigprocBuilder:
+        self._buf += self._DOUBLE.pack(v)
+        return self
+
+    def _write_byte(self, v: int) -> SigprocBuilder:
+        self._buf += self._BYTE.pack(v)
+        return self
+
+    def header_start(self) -> SigprocBuilder:
+        return self._write_string("HEADER_START")
+
+    def header_end(self) -> SigprocBuilder:
+        return self._write_string("HEADER_END")
+
+    def uint_field(self, key: str, value: int) -> SigprocBuilder:
+        return self._write_string(key)._write_uint(value)
+
+    def double_field(self, key: str, value: float) -> SigprocBuilder:
+        return self._write_string(key)._write_double(value)
+
+    def byte_field(self, key: str, value: int) -> SigprocBuilder:
+        return self._write_string(key)._write_byte(value)
+
+    def string_field(self, key: str, value: str) -> SigprocBuilder:
+        return self._write_string(key)._write_string(value)
+
+    def raw(self, data: bytes) -> SigprocBuilder:
+        """Append raw bytes (for data block or deliberate corruption)."""
+        self._buf += data
+        return self
+
+    def build(self) -> bytes:
+        return bytes(self._buf)
+
+
+@pytest.fixture
+def builder() -> SigprocBuilder:
+    return SigprocBuilder()
+
+
+def _minimal_payload(
+    b: SigprocBuilder,
+    *,
+    nchans: int = 4,
+    nbits: int = 8,
+    nsamples: int | None = None,
+    data: bytes | None = None,
+) -> SigprocBuilder:
+    """Write a minimal payload for reuse across tests."""
+    base = (
+        b.header_start()
+        .string_field("source_name", "test_src")
+        .uint_field("nchans", nchans)
+        .uint_field("nbits", nbits)
+    )
+    if nsamples is not None:
+        base.uint_field("nsamples", nsamples)
+    base = (
+        base.double_field("tsamp", 6.4e-5)
+        .double_field("fch1", 1500.0)
+        .double_field("foff", -0.1)
+        .double_field("tstart", 60000.0)
+        .header_end()
+    )
+    if data is not None:
+        return base.raw(data)
+    return base
+
+
+class TestReadString:
+    def test_roundtrip(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        f.write_bytes(sigproc._encode_string("HEADER_START"))
+        with f.open("rb") as fp:
+            assert sigproc._read_string(fp) == "HEADER_START"
+
+    def test_empty_file_raises(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        f.write_bytes(b"")
+        with (
+            f.open("rb") as fp,
+            pytest.raises(struct.error, match="EOF while reading string length"),
+        ):
+            sigproc._read_string(fp)
+
+    def test_truncated_body_raises(self, tmpfile: str) -> None:
+        # Write length=10 but only 3 bytes of body
+        f = Path(tmpfile)
+        f.write_bytes(struct.pack("<I", 10) + b"abc")
+        with (
+            f.open("rb") as fp,
+            pytest.raises(struct.error, match="EOF while reading string body"),
+        ):
+            sigproc._read_string(fp)
+
+    def test_implausible_length_raises(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        f.write_bytes(struct.pack("<I", 99_999))
+        with (
+            f.open("rb") as fp,
+            pytest.raises(ValueError, match="Implausible string length"),
+        ):
+            sigproc._read_string(fp)
+
+    def test_zero_length_raises(self, tmpfile: str) -> None:
+        # strlen=0 is outside the valid 1..4096 range
+        f = Path(tmpfile)
+        f.write_bytes(struct.pack("<I", 0))
+        with (
+            f.open("rb") as fp,
+            pytest.raises(ValueError, match="Implausible string length"),
+        ):
+            sigproc._read_string(fp)
+
+
+class TestEncodeKey:
+    def test_known_string_field(self) -> None:
+        result = sigproc.encode_key("source_name", value="CrabPulsar")
+        # Reconstruct expected manually
+        key_enc = struct.pack("<I", len("source_name")) + b"source_name"
+        val_enc = struct.pack("<I", len("CrabPulsar")) + b"CrabPulsar"
+        assert result == key_enc + val_enc
+
+    def test_known_uint_field(self) -> None:
+        result = sigproc.encode_key("nchans", value=1024)
+        key_enc = struct.pack("<I", len("nchans")) + b"nchans"
+        val_enc = struct.pack("<I", 1024)
+        assert result == key_enc + val_enc
+
+    def test_known_double_field(self) -> None:
+        result = sigproc.encode_key("tsamp", value=6.4e-5)
+        key_enc = struct.pack("<I", len("tsamp")) + b"tsamp"
+        val_enc = struct.pack("<d", 6.4e-5)
+        assert result == key_enc + val_enc
+
+    def test_known_byte_field(self) -> None:
+        result = sigproc.encode_key("signed", value=1)
+        key_enc = struct.pack("<I", len("signed")) + b"signed"
+        val_enc = struct.pack("b", 1)
+        assert result == key_enc + val_enc
+
+    def test_key_only_no_value(self) -> None:
+        # encode_key with no value should only encode the key string
+        result = sigproc.encode_key("HEADER_START")
+        expected = struct.pack("<I", len("HEADER_START")) + b"HEADER_START"
+        assert result == expected
+
+    def test_unknown_key_raises(self) -> None:
+        with pytest.raises(KeyError, match="Unknown SIGPROC header key"):
+            sigproc.encode_key("bogus_key", value=42)
+
+    def test_wrong_type_for_string_field_raises(self) -> None:
+        with pytest.raises(TypeError, match="expects a string value"):
+            sigproc.encode_key("source_name", value=42)
+
+
+class TestEncodeHeader:
+    def test_roundtrip(self, filfile_8bit_1_header: dict, tmpfile: str) -> None:
+        """Encode → write → parse_header should recover the same values."""
+        bytes_data = (
+            filfile_8bit_1_header["nsamples"]
+            * filfile_8bit_1_header["nchans"]
+            * (filfile_8bit_1_header["nbits"] // 8)
+        )
+        payload = sigproc.encode_header(filfile_8bit_1_header) + bytes(bytes_data)
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        parsed = sigproc.parse_header(f)
+        for key, val in filfile_8bit_1_header.items():
+            if isinstance(val, float):
+                assert parsed[key] == pytest.approx(val), (
+                    f"Float mismatch on key {key!r}"
+                )
+            else:
+                assert parsed[key] == val, f"Value mismatch on key {key!r}"
+
+    def test_deterministic_ordering(self, filfile_8bit_1_header: dict) -> None:
+        """Encoding the same header twice must produce identical bytes."""
+        assert sigproc.encode_header(filfile_8bit_1_header) == sigproc.encode_header(
+            filfile_8bit_1_header
+        )
+
+    def test_nsamples_excluded_by_default(self, filfile_8bit_1_header: dict) -> None:
+        h = {**filfile_8bit_1_header, "nsamples": 1000}
+        encoded = sigproc.encode_header(h)
+        # nsamples should not appear in the output unless explicitly allowed
+        assert b"nsamples" not in encoded
+
+    def test_nsamples_included_when_allowed(self, filfile_8bit_1_header: dict) -> None:
+        h = {**filfile_8bit_1_header, "nsamples": 1000}
+        encoded = sigproc.encode_header(h, allow_nsamples_overwrite=True)
+        assert b"nsamples" in encoded
+
+    def test_unknown_keys_in_dict_are_silently_ignored(
+        self, filfile_8bit_1_header: dict
+    ) -> None:
+        h = {**filfile_8bit_1_header, "my_custom_key": 42}
+        # Should not raise — unknown keys are simply skipped
+        encoded = sigproc.encode_header(h)
+        assert b"my_custom_key" not in encoded
+
+    def test_starts_with_header_start(self, filfile_8bit_1_header: dict) -> None:
+        encoded = sigproc.encode_header(filfile_8bit_1_header)
+        expected_start = struct.pack("<I", len("HEADER_START")) + b"HEADER_START"
+        assert encoded.startswith(expected_start)
+
+    def test_ends_with_header_end(self, filfile_8bit_1_header: dict) -> None:
+        encoded = sigproc.encode_header(filfile_8bit_1_header)
+        expected_end = struct.pack("<I", len("HEADER_END")) + b"HEADER_END"
+        assert encoded.endswith(expected_end)
+
+
+class TestParseHeaderValid:
+    def test_computed_fields_present(
+        self, filfile_8bit_1: str, filfile_8bit_1_header: dict
+    ) -> None:
+        h = sigproc.parse_header(filfile_8bit_1)
+        assert "hdrlen" in h
+        assert "filelen" in h
+        assert "datalen" in h
+        assert "nsamples" in h
+        assert "filename" in h
+        for key, expected_value in filfile_8bit_1_header.items():
+            assert h[key] == expected_value
+
+    def test_filename_is_absolute_posix(self, filfile_8bit_1: str) -> None:
+        h = sigproc.parse_header(filfile_8bit_1)
+        assert h["filename"] == Path(filfile_8bit_1).resolve().as_posix()
+
+    def test_accepts_path_and_str(self, filfile_8bit_1: Path) -> None:
+        h_path = sigproc.parse_header(filfile_8bit_1)
+        h_str = sigproc.parse_header(str(filfile_8bit_1))
+        assert h_path == h_str
+
+    def test_nsamples_in_header_agrees(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """When header nsamples matches file, no warning, value preserved."""
+        nchans, nbits, nsamples = 4, 8, 50
+        data = bytes(nchans * nsamples)
+        payload = (
+            builder.header_start()
+            .string_field("source_name", "src")
+            .uint_field("nchans", nchans)
+            .uint_field("nbits", nbits)
+            .uint_field("nsamples", nsamples)  # declared == actual
+            .double_field("tsamp", 6.4e-5)
+            .double_field("fch1", 1500.0)
+            .double_field("foff", -0.1)
+            .double_field("tstart", 60000.0)
+            .header_end()
+            .raw(data)
+            .build()
+        )
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        h = sigproc.parse_header(f)
+        assert h["nsamples"] == nsamples
+
+    def test_nsamples_in_header_too_large_clamped(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """Header declares more samples than exist on disk → clamp to file size."""
+        nchans, nbits, actual = 4, 8, 50
+        data = bytes(nchans * actual)
+        payload = _minimal_payload(
+            builder,
+            nchans=nchans,
+            nbits=nbits,
+            nsamples=actual + 1000,  # declared > actual
+            data=data,
+        ).build()
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        h = sigproc.parse_header(f)
+        assert h["nsamples"] == actual  # clamped to what's actually there
+
+    def test_nsamples_in_header_too_small_used(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """Header declares fewer samples than disk — trust the header (min wins)."""
+        nchans, nbits, declared = 4, 8, 30
+        data = bytes(nchans * 50)  # 50 samples on disk
+        payload = _minimal_payload(
+            builder,
+            nchans=nchans,
+            nbits=nbits,
+            nsamples=declared,
+            data=data,
+        ).build()
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        h = sigproc.parse_header(f)
+        assert h["nsamples"] == declared
+
+    def test_unknown_key_skipped(self, tmpfile: str, builder: SigprocBuilder) -> None:
+        """Unknown keys with uint-sized values should be skipped gracefully."""
+        nchans, nbits, nsamples = 4, 8, 20
+        data = bytes(nchans * nsamples)
+        # Inject an unknown uint key between known keys
+        unknown_key = struct.pack("<I", len("mystery")) + b"mystery"
+        unknown_val = struct.pack("<I", 999)
+
+        base = _minimal_payload(builder, nchans=nchans, nbits=nbits).build()
+        # Splice unknown key+value right before HEADER_END
+        header_end_marker = struct.pack("<I", len("HEADER_END")) + b"HEADER_END"
+        split = base.rfind(header_end_marker)
+        crafted = base[:split] + unknown_key + unknown_val + base[split:]
+
+        f = Path(tmpfile)
+        f.write_bytes(crafted + data)
+        h = sigproc.parse_header(f)
+        # Must still parse correctly and not contain the unknown key
+        assert "mystery" not in h
+        assert h["nchans"] == nchans
+
+    def test_empty_data_block_warns(
+        self, tmpfile: str, builder: SigprocBuilder, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Header-only file with no data block should log a warning, not crash."""
+        payload = _minimal_payload(builder).build()  # no data appended
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        with caplog.at_level(logging.WARNING):
+            h = sigproc.parse_header(f)
+        assert h["nsamples"] == 0
+        assert any("nsamples is zero" in r.message for r in caplog.records)
+
+
+class TestParseHeaderInvalid:
+    def test_empty_file(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        f.write_bytes(b"")
+        with pytest.raises(OSError, match="sigproc format"):
+            sigproc.parse_header(f)
+
+    def test_wrong_sentinel(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        f.write_bytes(struct.pack("<I", 12) + b"HEADER_NOPE!")
+        with pytest.raises(OSError, match="not in sigproc format"):
+            sigproc.parse_header(f)
+
+    def test_file_not_found(self, tmpfile: str) -> None:
+        f = Path(tmpfile)
+        with pytest.raises(OSError):
+            sigproc.parse_header(f)
+
+    def test_truncated_mid_key(self, tmpfile: str, builder: SigprocBuilder) -> None:
+        """File ends abruptly inside a key string."""
+        payload = builder.header_start().build()
+        # Append a partial key: length says 6 bytes but only 3 follow
+        payload += struct.pack("<I", 6) + b"abc"
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        with pytest.raises(OSError, match="truncated"):
+            sigproc.parse_header(f)
+
+    def test_truncated_mid_value(self, tmpfile: str, builder: SigprocBuilder) -> None:
+        """File ends abruptly inside a known key's value."""
+        payload = builder.header_start().build()
+        payload += struct.pack("<I", len("nchans")) + b"nchans"
+        payload += b"\x00\x00"  # only 2 bytes of a 4-byte uint
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        with pytest.raises(OSError, match="truncated"):
+            sigproc.parse_header(f)
+
+    def test_missing_required_keys_raises(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """Header missing nbits/nchans should raise ValueError."""
+        f = Path(tmpfile)
+        payload = (
+            builder.header_start()
+            .string_field("source_name", "src")
+            # nbits and nchans deliberately omitted
+            .double_field("tsamp", 6.4e-5)
+            .header_end()
+            .build()
+        )
+        f.write_bytes(payload)
+        with pytest.raises(ValueError, match="missing required header keys"):
+            sigproc.parse_header(f)
+
+    def test_zero_nbits_raises(self, tmpfile: str, builder: SigprocBuilder) -> None:
+        payload = (
+            builder.header_start()
+            .uint_field("nchans", 4)
+            .uint_field("nbits", 0)  # invalid
+            .double_field("tsamp", 6.4e-5)
+            .header_end()
+            .build()
+        )
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        with pytest.raises(ValueError, match="nbits=0"):
+            sigproc.parse_header(f)
+
+    def test_raises_on_completely_unresolvable_key(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """No candidate size produces a valid next key — must raise OSError."""
+        nchans, nbits = 4, 8
+        base = _minimal_payload(builder, nchans=nchans, nbits=nbits).build()
+        # Inject: unknown key name + pure garbage bytes that cannot be
+        # interpreted as any valid next key at any candidate offset.
+        unknown_key = struct.pack("<I", len("mystery")) + b"mystery"
+        garbage = b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+
+        header_end = struct.pack("<I", len("HEADER_END")) + b"HEADER_END"
+        split = base.rfind(header_end)
+        crafted = base[:split] + unknown_key + garbage
+        # Deliberately omit HEADER_END so every probe fails to find a valid next key
+
+        f = Path(tmpfile)
+        f.write_bytes(crafted)
+        with pytest.raises(OSError, match="Cannot determine size"):
+            sigproc.parse_header(f)
+
+    def test_eof_during_skip_tries_smaller(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """EOF mid-skip causes the loop to try the next candidate size."""
+        # Inject unknown key with only 2 bytes of value (less than any candidate),
+        # followed by HEADER_END — the skip loop will exhaust all candidates and raise.
+        base = _minimal_payload(builder, nchans=4, nbits=8).build()
+        unknown_key = struct.pack("<I", len("mystery")) + b"mystery"
+        # 2 bytes — smaller than _BYTE (1B candidate will succeed reading 1 byte,
+        # but then the remaining 1 byte won't parse as a valid key string)
+        partial_value = b"\x00\x00"
+        header_end = struct.pack("<I", len("HEADER_END")) + b"HEADER_END"
+        split = base.rfind(header_end)
+        crafted = base[:split] + unknown_key + partial_value
+        # No HEADER_END after garbage — ensures failure
+
+        f = Path(tmpfile)
+        f.write_bytes(crafted)
+        with pytest.raises(OSError):
+            sigproc.parse_header(f)
+
+    def test_negative_datalen_raises(
+        self, tmpfile: str, monkeypatch: pytest.MonkeyPatch, builder: SigprocBuilder
+    ) -> None:
+        """Make datalen < 0 branch: mock filelen to be smaller than hdrlen."""
+        import sigpyproc.io.sigproc as _mod  # noqa: PLC0415
+
+        nchans, nbits = 4, 8
+        payload = _minimal_payload(builder, nchans=nchans, nbits=nbits).build()
+        f = Path(tmpfile)
+        f.write_bytes(payload)  # header only, no data — datalen == 0, not negative
+
+        # Force filelen to appear smaller than hdrlen by patching fp.seek/tell.
+        # Simplest alternative: patch _read_sigproc_header to return a hdrlen
+        # larger than the actual file size.
+        original_read = _mod._read_sigproc_header
+
+        def _patched_read(fp: BinaryIO, filepath: Path) -> dict:
+            result = original_read(fp, filepath)
+            result["hdrlen"] = result["hdrlen"] + 999  # larger than file
+            return result
+
+        monkeypatch.setattr(_mod, "_read_sigproc_header", _patched_read)
+        with pytest.raises(OSError, match="smaller than header"):
+            sigproc.parse_header(f)
+
+
+class TestNsamplesInBinaryHeader:
+    def test_returns_true_when_present(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        nchans, nbits, nsamples = 4, 8, 50
+        payload = _minimal_payload(
+            builder,
+            nchans=nchans,
+            nbits=nbits,
+            nsamples=nsamples,
+            data=bytes(nchans * nsamples),
+        ).build()
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        assert sigproc._nsamples_in_binary_header(f) is True
+
+    def test_returns_false_when_absent(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        nchans, nbits, nsamples = 4, 8, 50
+        payload = _minimal_payload(
+            builder,
+            nchans=nchans,
+            nbits=nbits,
+            data=bytes(nchans * nsamples),
+        ).build()
+        f = Path(tmpfile)
+        f.write_bytes(payload)
+        assert sigproc._nsamples_in_binary_header(f) is False
+
+    def test_skips_unknown_key_before_nsamples(
+        self, tmpfile: str, builder: SigprocBuilder
+    ) -> None:
+        """Exercises the _skip_unknown_key branch inside _nsamples_in_binary_header."""
+        nchans, nbits, nsamples = 4, 8, 50
+        data = bytes(nchans * nsamples)
+        base = _minimal_payload(builder, nchans=nchans, nbits=nbits).build()
+        # Inject unknown uint key + nsamples before HEADER_END
+        unknown = struct.pack("<I", len("mystery")) + b"mystery" + struct.pack("<I", 42)
+        nsamples_field = (
+            struct.pack("<I", len("nsamples"))
+            + b"nsamples"
+            + struct.pack("<I", nsamples)
+        )
+        header_end = struct.pack("<I", len("HEADER_END")) + b"HEADER_END"
+
+        split = base.rfind(header_end)
+        crafted = base[:split] + unknown + nsamples_field + base[split:]
+
+        f = Path(tmpfile)
+        f.write_bytes(crafted + data)
+        assert sigproc._nsamples_in_binary_header(f) is True
+
+
+class TestSigproc:
     @pytest.mark.parametrize(
-        ("ra", "dec"),
+        ("src_raj", "src_dej", "ra_str", "dec_str"),
         [
-            ("15h42m30.1234s", "+00d12m00.1234s"),
-            ("00h42m30.1234s", "+41d12m00.1234s"),
-            ("00h42m30.1234s", "-41d12m00.1234s"),
+            (154230.1234, 1200.1234, "15h42m30.1234s", "+00d12m00.1234s"),
+            (4230.1234, 411200.1234, "00h42m30.1234s", "+41d12m00.1234s"),
+            (4230.1234, -411200.1234, "00h42m30.1234s", "-41d12m00.1234s"),
         ],
     )
-    def test_parse_radec(self, ra: str, dec: str) -> None:
-        coord = SkyCoord(ra, dec, frame="icrs")
-        src_raj = ra.translate({ord(ch): None for ch in "hdms"})
-        src_dej = dec.translate({ord(ch): None for ch in "hdms"})
-        sig_coord = sigproc.parse_radec(float(src_raj), float(src_dej))
-        np.testing.assert_allclose(sig_coord.ra.deg, coord.ra.deg)
-        np.testing.assert_allclose(sig_coord.dec.deg, coord.dec.deg)
-
-    def test_encode_key_str(self) -> None:
-        key = "testkey"
-        keylen_enc = struct.pack("I", len(key)).decode()
-        assert sigproc.encode_key("testkey") == f"{keylen_enc}{key}".encode()
-        value = "value"
-        valuelen_enc = struct.pack("I", len(value)).decode()
-        assert (
-            sigproc.encode_key("testkey", value=value, value_type="str")
-            == f"{keylen_enc}{key}{valuelen_enc}{value}".encode()
-        )
-
-    @pytest.mark.parametrize(("value", "val_type"), [(123, "I"), (123.456, "d")])
-    def test_encode_key_other(self, value: float, val_type: str) -> None:
-        key = "testkey"
-        keylen_enc = struct.pack("I", len(key))
-        value_enc = struct.pack(val_type, value)
-        assert (
-            sigproc.encode_key(key, value=value, value_type=val_type)
-            == keylen_enc + key.encode() + value_enc
-        )
-
-    def test_encode_header(self) -> None:
-        pass
-
-    def test_parse_header(
-        self,
-        filfile_8bit_1: str,
-        filfile_8bit_1_header: dict,
+    def test_parse_radec(
+        self, src_raj: float, src_dej: float, ra_str: str, dec_str: str
     ) -> None:
-        header = sigproc.parse_header(filfile_8bit_1)
-        for key, expected_value in filfile_8bit_1_header.items():
-            assert header[key] == expected_value
-
-    def test_parse_header_invalid(self, tmpfile: str) -> None:
-        with Path(tmpfile).open(mode="wb") as wf:
-            wf.write(b"HEADER_STARTNOT")
-        with pytest.raises(OSError):
-            sigproc.parse_header(tmpfile)
-        with Path(tmpfile).open(mode="wb") as wf:
-            wf.write(b"5")
-        with pytest.raises(OSError):
-            sigproc.parse_header(tmpfile)
+        expected = SkyCoord(ra_str, dec_str, frame="icrs")
+        result = sigproc.parse_radec(src_raj, src_dej)
+        np.testing.assert_allclose(result.ra.deg, expected.ra.deg, atol=1e-6)
+        np.testing.assert_allclose(result.dec.deg, expected.dec.deg, atol=1e-6)
 
     @pytest.mark.parametrize(
         ("key", "newval"),
@@ -95,6 +585,20 @@ class TestSigproc:
         header = sigproc.parse_header(tmpfile)
         assert header[key] == newval
 
+    def test_edit_header_source_name_truncated_to_original_length(
+        self, filfile_8bit_1: str, tmpfile: str
+    ) -> None:
+        """source_name edits are padded/truncated to preserve header size."""
+        shutil.copyfile(filfile_8bit_1, tmpfile)
+        original = sigproc.parse_header(tmpfile)
+        original_len = len(original["source_name"])
+        long_name = "X" * (original_len + 20)
+        sigproc.edit_header(tmpfile, "source_name", long_name)
+        header = sigproc.parse_header(tmpfile)
+        # Must be same byte length as before — header size is invariant
+        assert len(header["source_name"]) == original_len
+        assert header["hdrlen"] == original["hdrlen"]
+
     def test_edit_header_invalid(
         self,
         filfile_8bit_1: str,
@@ -103,8 +607,12 @@ class TestSigproc:
         shutil.copyfile(filfile_8bit_1, tmpfile)
         with pytest.raises(ValueError):
             sigproc.edit_header(tmpfile, "invalid", 0)
+        with pytest.raises((TypeError, struct.error)):
+            sigproc.edit_header(tmpfile, "nchans", "not_a_number")
         with pytest.raises(ValueError):
             sigproc.edit_header(tmpfile, "nchans", None)  # type: ignore [arg-type]
+        with pytest.raises(ValueError, match="non-ASCII characters"):
+            sigproc.edit_header(tmpfile, "source_name", "Ångström")
 
     def test_match_header_pass(self, filfile_8bit_1: str, filfile_8bit_2: str) -> None:
         header1 = sigproc.parse_header(filfile_8bit_1)
@@ -117,18 +625,19 @@ class TestSigproc:
     def test_match_header_fail(self, filfile_8bit_1: str, filfile_8bit_2: str) -> None:
         header1 = sigproc.parse_header(filfile_8bit_1)
         header2 = sigproc.parse_header(filfile_8bit_2)
-        header2["fch1"] += 1
+        header2["fch1"] += 1  # type: ignore [unsupported-operator]
         with pytest.raises(ValueError):
             sigproc.match_header(header1, header2)
 
-    def test_parse_header_multi(
+    def test_parse_header_multi_single_file(
         self,
         filfile_8bit_1: str,
         filfile_8bit_1_header: dict,
     ) -> None:
-        header = sigproc.parse_header_multi(filfile_8bit_1)
+        header, sinfo = sigproc.parse_header_multi(filfile_8bit_1)
         for key, expected_value in filfile_8bit_1_header.items():
             assert header[key] == expected_value
+        assert len(sinfo.entries) == 1
 
     def test_parse_header_multi_contiguity_pass(
         self,
@@ -180,11 +689,6 @@ class TestStreamInfo:
         assert stream_info.entries[0] == file_info
         assert stream_info.time_gaps == [0.0]
 
-    def test_stream_info_add_entry_invalid(self) -> None:
-        stream_info = sigproc.StreamInfo()
-        with pytest.raises(TypeError):
-            stream_info.add_entry("invalid")  # type: ignore [arg-type]
-
     def test_stream_info_check_contiguity_valid(self) -> None:
         tsamp = 0.001
         file_info1 = sigproc.FileInfo(
@@ -196,7 +700,8 @@ class TestStreamInfo:
             tsamp=tsamp,
         )
 
-        tstart_valid = file_info1.tstart + (file_info1.nsamples * tsamp) / 86400
+        # exactly one sample after last
+        tstart_valid = file_info1.tend + tsamp / 86400
         file_info2 = sigproc.FileInfo(
             filename="file2.txt",
             hdrlen=200,


### PR DESCRIPTION
- nsamples is a valid keyword now. header_keys is more robust SIGPROC_SCHEMA.
- Enhanced test coverage for encoding and parsing headers, including edge cases for nsamples.

Parsing rule:
- sigproc header parsing should skip invalid keywords (only warning, no error).
- `nsamples` is added to valid keywords (read-only). At runtime, we choose the minimum of the two (file size or metadata) and issue a warning.
- Since `nsamples` is a legacy keyword (as per sigproc original documentation), sigpyproc will only support reading and not writing.